### PR TITLE
Remove code that is no longer needed.

### DIFF
--- a/text-recognition/final/text-recognition/text-recognition/ViewController.swift
+++ b/text-recognition/final/text-recognition/text-recognition/ViewController.swift
@@ -39,8 +39,9 @@ class ViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSo
   
   override func viewDidLoad() {
     super.viewDidLoad()
-    textRecognizer = Vision.vision().onDeviceTextRecognizer()
-    cloudTextRecognizer = Vision.vision().cloudTextRecognizer()
+    let vision = Vision.vision()
+    textRecognizer = vision.onDeviceTextRecognizer()
+    cloudTextRecognizer = vision.cloudTextRecognizer()
     
     imageView.layer.addSublayer(frameSublayer)
     pickerView.dataSource = self
@@ -69,12 +70,7 @@ class ViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSo
   func runCloudTextRecognition(with image: UIImage) {
     let visionImage = VisionImage(image: image)
     cloudTextRecognizer.process(visionImage, completion: { (features, error) in
-      if let error = error {
-        print("Received error: \(error)")
-        return
-      }
-      
-      self.processCloudResult(from: features, error: error)
+      self.processResult(from: features, error: error)
     })
   }
 
@@ -94,26 +90,6 @@ class ViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSo
             imageSize: image.size,
             viewFrame: self.imageView.frame,
             text: element.text
-          )
-        }
-      }
-    }
-  }
-
-  
-  func processCloudResult(from text: VisionText?, error: Error?) {
-    removeFrames()
-    guard let features = text, let image = imageView.image else {
-      return
-    }
-    for block in features.blocks {
-      for line in block.lines {
-        for word in line.elements {
-          self.addFrameView(
-            featureFrame: word.frame,
-            imageSize: image.size,
-            viewFrame: self.imageView.frame,
-            text: word.text
           )
         }
       }

--- a/text-recognition/starter/text-recognition/text-recognition/ViewController.swift
+++ b/text-recognition/starter/text-recognition/text-recognition/ViewController.swift
@@ -69,11 +69,6 @@ class ViewController: UIViewController, UIPickerViewDelegate, UIPickerViewDataSo
   }
 
   
-  func processCloudResult(from text: VisionText?, error: Error?) {
-    
-  }
-
-  
   /// Converts a feature frame to a frame UIView that is displayed over the image.
   ///
   /// - Parameters:


### PR DESCRIPTION
Before, since the Cloud SDK passed a different object type to the closure, we needed a different method for getting the text from the image. Now the mobile and Cloud ML Kit SDKs both pass the same result type, so we just need one function: process result.

Also made one change to the use of `Vision.vision()` to match how it is shown in the codelab.