### PR TITLE
Firecast mods

### DIFF
--- a/starter/MLKit-codelab/ViewController.swift
+++ b/starter/MLKit-codelab/ViewController.swift
@@ -14,8 +14,6 @@
 //  limitations under the License.
 //
 
-import FirebaseMLVision
-import FirebaseMLModelInterpreter
 
 class ViewController: UIViewController {
 

--- a/starter/Podfile
+++ b/starter/Podfile
@@ -2,12 +2,5 @@ platform :ios, '9.0'
 # Comment the next line if you're not using Swift and don't want to use dynamic frameworks
 use_frameworks!
 
-pod 'Firebase/Core'
-pod 'Firebase/MLVision'
-pod 'Firebase/MLVisionFaceModel'
-pod 'Firebase/MLVisionLabelModel'
-pod 'Firebase/MLModelInterpreter'
-pod 'Firebase/MLVisionTextModel'
-
 target 'MLKit-codelab' do
 end


### PR DESCRIPTION
removed Podfile pods to align to the codelab which tells you to add them.

Also removed module imports from top of ViewController class so app can run without having to install all pods upfront. This means I can make a more modular Firecast covering each of the three topics separately.